### PR TITLE
Add assertions for internal invariants

### DIFF
--- a/src/main/java/alioth/Alioth.java
+++ b/src/main/java/alioth/Alioth.java
@@ -1,6 +1,6 @@
 package alioth;
 
-import java.nio.file.Paths;
+import java.nio.file.Path;
 
 import alioth.command.Command;
 import alioth.storage.Storage;
@@ -20,9 +20,11 @@ public class Alioth {
      *
      * @param filePath File path for the storage file.
      */
-    public Alioth(String filePath) {
+    public Alioth(Path filePath) {
+        assert filePath != null : "Storage path should not be null";
+
         ui = new Ui();
-        storage = new Storage(Paths.get(filePath));
+        storage = new Storage(filePath);
 
         TaskList tempTasks;
         try {

--- a/src/main/java/alioth/Message.java
+++ b/src/main/java/alioth/Message.java
@@ -36,7 +36,6 @@ public enum Message {
     /**
      * Returns the corresponding invalid-index message for the given command word.
      *
-     * @param commandWord The command word (e.g., "mark", "unmark", "delete").
      * @return The message corresponding to the command word, or UNKNOWN_COMMAND if none matches.
      */
     public static Message invalidIndexCommand(String commandWord) {
@@ -48,7 +47,7 @@ public enum Message {
         case "delete":
             return INVALID_DELETE;
         default:
-            return UNKNOWN_COMMAND; // fallback; shouldn't happen if you use it correctly
+            return UNKNOWN_COMMAND;
         }
     }
 }

--- a/src/main/java/alioth/Parser.java
+++ b/src/main/java/alioth/Parser.java
@@ -29,6 +29,8 @@ public class Parser {
      * @throws AliothException If the input is invalid or the command is unknown.
      */
     public static Command parse(String input) throws AliothException {
+        assert input != null : "Parser.parse input should not be null";
+
         if (!input.equals(input.stripLeading())) {
             throw new AliothException(Message.LEADING_SPACES.getText());
         }

--- a/src/main/java/alioth/gui/DialogBox.java
+++ b/src/main/java/alioth/gui/DialogBox.java
@@ -29,6 +29,8 @@ public class DialogBox extends HBox {
             fxmlLoader.setController(this);
             fxmlLoader.setRoot(this);
             fxmlLoader.load();
+            assert dialog != null && displayPicture != null
+                    : "FXML injection failed in DialogBox";
         } catch (IOException e) {
             e.printStackTrace();
         }

--- a/src/main/java/alioth/gui/MainApp.java
+++ b/src/main/java/alioth/gui/MainApp.java
@@ -1,6 +1,7 @@
 package alioth.gui;
 
 import java.io.IOException;
+import java.nio.file.Paths;
 
 import alioth.Alioth;
 import javafx.application.Application;
@@ -13,7 +14,7 @@ import javafx.stage.Stage;
  * A GUI for Alioth using FXML.
  */
 public class MainApp extends Application {
-    private final Alioth alioth = new Alioth("data/alioth.txt");
+    private final Alioth alioth = new Alioth(Paths.get("data", "alioth.txt"));
 
     @Override
     public void start(Stage stage) {
@@ -25,6 +26,7 @@ public class MainApp extends Application {
             stage.setScene(scene);
 
             MainWindow controller = fxmlLoader.getController();
+            assert controller != null : "Failed to get controller in MainApp";
             controller.setAlioth(alioth);
 
             stage.show();

--- a/src/main/java/alioth/gui/MainWindow.java
+++ b/src/main/java/alioth/gui/MainWindow.java
@@ -34,6 +34,10 @@ public class MainWindow extends AnchorPane {
      */
     @FXML
     public void initialize() {
+        assert scrollPane != null && dialogContainer != null
+                && userInput != null && sendButton != null
+                : "FXML injection failed in MainWindow";
+
         scrollPane.vvalueProperty().bind(dialogContainer.heightProperty());
     }
 

--- a/src/main/java/alioth/storage/Storage.java
+++ b/src/main/java/alioth/storage/Storage.java
@@ -3,7 +3,6 @@ package alioth.storage;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
@@ -33,6 +32,7 @@ public class Storage {
      * @param filePath Path to the save file.
      */
     public Storage(Path filePath) {
+        assert filePath != null : "Storage filePath should not be null";
         this.filePath = filePath;
     }
 
@@ -72,6 +72,8 @@ public class Storage {
      * @throws AliothException If there is an IO problem.
      */
     public void save(List<Task> tasks) throws AliothException {
+        assert tasks != null : "Tasks list to save should not be null";
+
         try {
             Path parent = filePath.getParent();
             if (parent != null) {
@@ -197,14 +199,5 @@ public class Storage {
         }
 
         return "T | " + doneFlag + " | " + task.getDescription();
-    }
-
-    /**
-     * Creates the default storage file path.
-     *
-     * @return Default save file path.
-     */
-    public static Path getDefaultPath() {
-        return Paths.get("data", "alioth.txt");
     }
 }

--- a/src/main/java/alioth/task/Deadline.java
+++ b/src/main/java/alioth/task/Deadline.java
@@ -20,6 +20,7 @@ public class Deadline extends Task {
      */
     public Deadline(String description, LocalDate by) {
         super(description);
+        assert by != null : "Deadline 'by' date should not be null";
         this.by = by;
     }
 

--- a/src/main/java/alioth/task/Event.java
+++ b/src/main/java/alioth/task/Event.java
@@ -22,6 +22,8 @@ public class Event extends Task {
      */
     public Event(String description, LocalDateTime from, LocalDateTime to) {
         super(description);
+        assert from != null : "Event 'from' should not be null";
+        assert to != null : "Event 'to' should not be null";
         this.from = from;
         this.to = to;
     }

--- a/src/main/java/alioth/task/Task.java
+++ b/src/main/java/alioth/task/Task.java
@@ -14,6 +14,7 @@ public class Task {
      * @param description Description of the task.
      */
     public Task(String description) {
+        assert description != null : "Task description should not be null";
         this.description = description;
         this.isDone = false;
     }

--- a/src/main/java/alioth/task/TaskList.java
+++ b/src/main/java/alioth/task/TaskList.java
@@ -22,6 +22,7 @@ public class TaskList {
      * @param tasks The list of tasks to copy from.
      */
     public TaskList(List<Task> tasks) {
+        assert tasks != null : "Task list to copy should not be null";
         this.tasks = new ArrayList<>(tasks);
     }
 
@@ -31,6 +32,7 @@ public class TaskList {
      * @param task Task to add.
      */
     public void add(Task task) {
+        assert task != null : "TaskList should not add null task";
         tasks.add(task);
     }
 
@@ -87,6 +89,6 @@ public class TaskList {
      * @return The list of tasks.
      */
     public List<Task> asList() {
-        return tasks;
+        return new ArrayList<>(tasks);
     }
 }


### PR DESCRIPTION
Some internal assumptions are not documented explicitly and failures can surface later as NullPointerException.

This makes programmer errors harder to diagnose because the root cause is not detected at the point of failure.

Add Java assert statements at key boundaries to document assumptions such as non-null storage paths, non-null task fields, and successful FXML injection.

These asserts catch internal logic bugs early without changing how user input errors are handled.