### PR TITLE
Improve parsing helpers and task list encapsulation

### DIFF
--- a/src/main/java/alioth/Parser.java
+++ b/src/main/java/alioth/Parser.java
@@ -10,7 +10,7 @@ import alioth.command.FindCommand;
 import alioth.command.ListCommand;
 import alioth.command.MarkCommand;
 import alioth.command.UnmarkCommand;
-
+import alioth.task.TaskList;
 /**
  * Parses user input into command objects.
  */
@@ -118,5 +118,28 @@ public class Parser {
         }
 
         return taskNumber;
+    }
+
+    /**
+     * Parses and validates a 1-based task index from the given arguments.
+     *
+     * Ensures the parsed task number refers to an existing task in the
+     * provided TaskList, then converts it to a 0-based index for internal use.
+     *
+     * @param tasks The task list used to validate the index range.
+     * @param args The argument string expected to contain the task number.
+     * @param commandWord The command word (used to construct error messages).
+     * @return The validated 0-based task index.
+     * @throws AliothException If the task number is missing, not an integer,
+     *                         or outside the valid range.
+     */
+    public static int parseTaskIndex(TaskList tasks, String args, String commandWord) throws AliothException {
+        int taskNumber = parseTaskNumber(args, commandWord);
+
+        if (taskNumber < 1 || taskNumber > tasks.size()) {
+            throw new AliothException(Message.invalidIndexCommand(commandWord).getText());
+        }
+
+        return taskNumber - 1; // convert to 0-based index
     }
 }

--- a/src/main/java/alioth/command/DeleteCommand.java
+++ b/src/main/java/alioth/command/DeleteCommand.java
@@ -1,7 +1,6 @@
 package alioth.command;
 
 import alioth.AliothException;
-import alioth.Message;
 import alioth.Parser;
 import alioth.storage.Storage;
 import alioth.task.Task;
@@ -25,20 +24,10 @@ public class DeleteCommand extends Command {
 
     @Override
     public void execute(TaskList tasks, Ui ui, Storage storage) throws AliothException {
-        int index = parseTaskIndex(tasks, args, "delete");
+        int index = Parser.parseTaskIndex(tasks, args, "delete");
         Task removed = tasks.remove(index);
 
         ui.showDeleteTask(removed, tasks.size());
         storage.save(tasks.asList());
-    }
-
-    private int parseTaskIndex(TaskList tasks, String args, String commandWord) throws AliothException {
-        int taskNumber = Parser.parseTaskNumber(args, commandWord);
-
-        if (taskNumber < 1 || taskNumber > tasks.size()) {
-            throw new AliothException(Message.invalidIndexCommand(commandWord).getText());
-        }
-
-        return taskNumber - 1;
     }
 }

--- a/src/main/java/alioth/command/MarkCommand.java
+++ b/src/main/java/alioth/command/MarkCommand.java
@@ -1,7 +1,6 @@
 package alioth.command;
 
 import alioth.AliothException;
-import alioth.Message;
 import alioth.Parser;
 import alioth.storage.Storage;
 import alioth.task.Task;
@@ -20,22 +19,12 @@ public class MarkCommand extends Command {
 
     @Override
     public void execute(TaskList tasks, Ui ui, Storage storage) throws AliothException {
-        int index = parseTaskIndex(tasks, args, "mark");
+        int index = Parser.parseTaskIndex(tasks, args, "mark");
 
         Task task = tasks.get(index);
         task.setDone(true);
 
         ui.showMarkTask(task);
         storage.save(tasks.asList());
-    }
-
-    private int parseTaskIndex(TaskList tasks, String args, String commandWord) throws AliothException {
-        int taskNumber = Parser.parseTaskNumber(args, commandWord);
-
-        if (taskNumber < 1 || taskNumber > tasks.size()) {
-            throw new AliothException(Message.invalidIndexCommand(commandWord).getText());
-        }
-
-        return taskNumber - 1;
     }
 }

--- a/src/main/java/alioth/command/UnmarkCommand.java
+++ b/src/main/java/alioth/command/UnmarkCommand.java
@@ -1,7 +1,6 @@
 package alioth.command;
 
 import alioth.AliothException;
-import alioth.Message;
 import alioth.Parser;
 import alioth.storage.Storage;
 import alioth.task.Task;
@@ -25,21 +24,11 @@ public class UnmarkCommand extends Command {
 
     @Override
     public void execute(TaskList tasks, Ui ui, Storage storage) throws AliothException {
-        int index = parseTaskIndex(tasks, args, "unmark");
+        int index = Parser.parseTaskIndex(tasks, args, "unmark");
         Task task = tasks.get(index);
         task.setDone(false);
 
         ui.showUnmarkTask(task);
         storage.save(tasks.asList());
-    }
-
-    private int parseTaskIndex(TaskList tasks, String args, String commandWord) throws AliothException {
-        int taskNumber = Parser.parseTaskNumber(args, commandWord);
-
-        if (taskNumber < 1 || taskNumber > tasks.size()) {
-            throw new AliothException(Message.invalidIndexCommand(commandWord).getText());
-        }
-
-        return taskNumber - 1;
     }
 }

--- a/src/main/java/alioth/task/TaskList.java
+++ b/src/main/java/alioth/task/TaskList.java
@@ -87,6 +87,6 @@ public class TaskList {
      * @return The list of tasks.
      */
     public List<Task> asList() {
-        return tasks;
+        return new ArrayList<>(tasks);
     }
 }


### PR DESCRIPTION
Index parsing logic is duplicated across multiple commands, task list state can be modified through the exposed internal list, and storage parsing mixes multiple concerns in a long method.

These issues reduce readability and increase the risk of unintended side effects.

Extract a shared task index parsing helper, return a defensive copy from TaskList, and refactor storage line parsing into small helper methods.

These changes improve encapsulation and keep the main logic at a single level of abstraction, making the code easier to read and maintain.