### PR TITLE
Use streams for task filtering and saving

### DIFF
--- a/src/main/java/alioth/storage/Storage.java
+++ b/src/main/java/alioth/storage/Storage.java
@@ -78,10 +78,9 @@ public class Storage {
                 Files.createDirectories(parent); // creates ./data if missing
             }
 
-            List<String> lines = new ArrayList<>();
-            for (Task task : tasks) {
-                lines.add(convertTaskToLine(task));
-            }
+            List<String> lines = tasks.stream()
+                    .map(this::convertTaskToLine)
+                    .toList();
 
             Files.write(filePath, lines);
         } catch (IOException e) {

--- a/src/main/java/alioth/task/TaskList.java
+++ b/src/main/java/alioth/task/TaskList.java
@@ -61,17 +61,10 @@ public class TaskList {
      * @return List of matching tasks.
      */
     public List<Task> find(String keyword) {
-        List<Task> matches = new ArrayList<>();
-
-        for (Task task : tasks) {
-            if (task.getDescription().contains(keyword)) {
-                matches.add(task);
-            }
-        }
-
-        return matches;
+        return tasks.stream()
+                .filter(task -> task.getDescription().contains(keyword))
+                .toList();
     }
-
     /**
      * Returns the number of tasks in the task list.
      *


### PR DESCRIPTION
Task filtering and save are implemented using explicit loops that manually build result lists.

This adds boilerplate and makes the intent of filtering and mapping less obvious.

Replace the loops with Java Stream pipelines to filter matching tasks and map tasks to their save-file lines.

Using Streams makes the code more declarative and keeps the main flow clear while preserving existing behavior.